### PR TITLE
ever so slightly smarter DSUs / dropStack

### DIFF
--- a/src/powercrystals/minefactoryreloaded/core/MFRUtil.java
+++ b/src/powercrystals/minefactoryreloaded/core/MFRUtil.java
@@ -19,6 +19,7 @@ import powercrystals.core.position.BlockPosition;
 import powercrystals.core.util.UtilInventory;
 import powercrystals.minefactoryreloaded.MineFactoryReloadedCore;
 import powercrystals.minefactoryreloaded.api.IToolHammer;
+import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
 
 public class MFRUtil
 {
@@ -113,6 +114,20 @@ public class MFRUtil
 				if(chest.getValue().getInvName() == "Engine")
 				{
 					continue;
+				}
+				if(chest.getValue() instanceof IDeepStorageUnit)
+				{
+					IDeepStorageUnit idsu = (IDeepStorageUnit)chest.getValue();
+					// don't put s in a DSU if it has NBT data
+					if(s.getTagCompound() != null)
+					{
+						continue;
+					}
+					// don't put s in a DSU if the stored quantity is nonzero and it's mismatched with the stored item type
+					if(idsu.getStoredItemType() != null && (idsu.getStoredItemType().itemID != s.itemID || idsu.getStoredItemType().getItemDamage() != s.getItemDamage()))
+					{
+						continue;
+					}
 				}
 				s.stackSize = UtilInventory.addToInventory(chest.getValue(), chest.getKey(), s);
 				if(s.stackSize == 0)

--- a/src/powercrystals/minefactoryreloaded/processing/TileEntityDeepStorageUnit.java
+++ b/src/powercrystals/minefactoryreloaded/processing/TileEntityDeepStorageUnit.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.common.ISidedInventory;
 import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
+import powercrystals.minefactoryreloaded.core.MFRUtil;
 import powercrystals.minefactoryreloaded.core.TileEntityFactory;
 
 public class TileEntityDeepStorageUnit extends TileEntityFactory implements IInventory, ISidedInventory, IDeepStorageUnit
@@ -90,6 +91,12 @@ public class TileEntityDeepStorageUnit extends TileEntityFactory implements IInv
 	}
 
 	@Override
+	public ForgeDirection getDropDirection()
+	{
+			return ForgeDirection.UP;
+	}
+
+	@Override
 	public void updateEntity()
 	{
 		super.updateEntity();
@@ -135,6 +142,12 @@ public class TileEntityDeepStorageUnit extends TileEntityFactory implements IInv
 					_storedQuantity += _inventory[slot].stackSize;
 					_inventory[slot] = null;
 				}
+			}
+			// boot improperly typed items from the input slots
+			else if(_inventory[slot].itemID != _storedId || _inventory[slot].getItemDamage() != _storedMeta || _inventory[slot].getTagCompound() != null)
+			{
+			MFRUtil.dropStack(this, _inventory[slot]);
+			_inventory[slot] = null;
 			}
 		}
 		


### PR DESCRIPTION
DSUs will eject nonmatching inputs using dropStack
dropStack behavior was changed to no longer consider nonmatching DSUs to
be a valid destination.
