### PR TITLE
Changed the way redstone cables render- they now render with alpha test

### DIFF
--- a/src/powercrystals/minefactoryreloaded/render/RedstoneCableModel.java
+++ b/src/powercrystals/minefactoryreloaded/render/RedstoneCableModel.java
@@ -92,7 +92,7 @@ public class RedstoneCableModel extends ModelBase
 		renderSide(entity.getConnectionState(ForgeDirection.DOWN), entity.getSideColor(ForgeDirection.DOWN),0,(float)-Math.PI/2, f5);
 	}
 	
-	private void renderSide(RedNetConnectionType state, int color, float yRot, float zRot, float scale)
+	private void renderModelState(RedNetConnectionType state, float yRot, float zRot, float scale)
 	{
 		switch (state)
 		{
@@ -108,10 +108,7 @@ public class RedstoneCableModel extends ModelBase
 			
 			_bandWhite.rotateAngleY = yRot;
 			_bandWhite.rotateAngleZ = zRot;
-			
-			GL11.glColor3f(_bandColors[color].x, _bandColors[color].y, _bandColors[color].z);
 			_bandWhite.render(scale);
-			GL11.glColor3f(1.0f, 1.0f, 1.0f);
 			break;
 		case PlateAll:
 			_interfaceConn.rotateAngleY = yRot;
@@ -133,12 +130,38 @@ public class RedstoneCableModel extends ModelBase
 			
 			_bandWhite.rotateAngleY = yRot;
 			_bandWhite.rotateAngleZ = zRot;
-			GL11.glColor3f(_bandColors[color].x, _bandColors[color].y, _bandColors[color].z);
 			_bandWhite.render(scale);
-			GL11.glColor3f(1.0f, 1.0f, 1.0f);
 			break;
 		default:
 			break;
+		}
+	}
+	
+	private void renderSide(RedNetConnectionType state, int color, float yRot, float zRot, float scale)
+	{
+		if (state == RedNetConnectionType.CableSingle || state == RedNetConnectionType.PlateSingle)
+		{
+			GL11.glDisable(GL11.GL_TEXTURE_2D);
+			GL11.glDisable(GL11.GL_LIGHTING);
+			GL11.glColor3f(_bandColors[color].x, _bandColors[color].y, _bandColors[color].z);
+			renderModelState(state, yRot, zRot, scale);
+			
+			GL11.glEnable(GL11.GL_TEXTURE_2D);
+			GL11.glEnable(GL11.GL_LIGHTING);
+			GL11.glColor3f(1.0f, 1.0f, 1.0f);
+			
+			GL11.glEnable(GL11.GL_BLEND);
+			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+			GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);
+			GL11.glPolygonOffset(0, -1);
+		}
+		
+		renderModelState(state, yRot, zRot, scale);
+		
+		if (state == RedNetConnectionType.CableSingle || state == RedNetConnectionType.PlateSingle)
+		{
+			GL11.glDisable(GL11.GL_BLEND);
+			GL11.glDisable(GL11.GL_POLYGON_OFFSET_FILL);
 		}
 	}
 

--- a/src/powercrystals/minefactoryreloaded/render/RedstoneCableRenderer.java
+++ b/src/powercrystals/minefactoryreloaded/render/RedstoneCableRenderer.java
@@ -29,7 +29,9 @@ public class RedstoneCableRenderer extends TileEntitySpecialRenderer implements 
 		GL11.glPushMatrix();
 		GL11.glTranslatef((float) x + 0.5F, (float) y + 0.5f, (float) z + 0.5F);
 		
+		GL11.glDisable(GL11.GL_ALPHA_TEST);
 		_model.render(cable,0.0625f);
+		GL11.glEnable(GL11.GL_ALPHA_TEST);
 
 		GL11.glPopMatrix();
 	}
@@ -43,7 +45,11 @@ public class RedstoneCableRenderer extends TileEntitySpecialRenderer implements 
 		GL11.glRotatef(90, 0, 1, 0);
 		GL11.glTranslated(0.12, 0, 0);
 		GL11.glScalef(1.28f, 1.28f, 1.28f);
+		
+		GL11.glDisable(GL11.GL_ALPHA_TEST);
 		_model.render(0.0625f);
+		GL11.glEnable(GL11.GL_ALPHA_TEST);
+		
 		GL11.glPopMatrix();
 		
 		return;


### PR DESCRIPTION
deactivated, but sides with color bands will now blend the side's geometry with the color band color, by alpha.  This will require the color band texturing to be reworked (we no longer multiply the color through the color band texture) to add transparency to the color band texturing.  However, this should allow the artist to apply transparency to arbitrary areas of the cable texture- the band color will be blended in on those areas, and when those segments of the texture are used for non-banded geometry, the alpha value will be ignored.
