### PR TITLE
Conveyor Belt Options: Never capture players & Never capture TC golems

### DIFF
--- a/src/powercrystals/minefactoryreloaded/block/BlockConveyor.java
+++ b/src/powercrystals/minefactoryreloaded/block/BlockConveyor.java
@@ -128,6 +128,14 @@ public class BlockConveyor extends BlockContainer implements IConnectableRedNet
 	@Override
 	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity)
 	{
+                if (entity instanceof EntityPlayer && MFRConfig.conveyorNeverCapturesPlayers.getBoolean(false)){
+                    return;
+                }
+                
+                if (entity.getClass().getName().contains("thaumcraft.common.entities.golems") && MFRConfig.conveyorNeverCapturesTCGolems.getBoolean(false)){
+                    return;
+                }
+                
 		if(!(entity instanceof EntityItem || entity instanceof EntityXPOrb || (entity instanceof EntityLiving && MFRConfig.conveyorCaptureNonItems.getBoolean(true))))
 		{
 			return;

--- a/src/powercrystals/minefactoryreloaded/setup/MFRConfig.java
+++ b/src/powercrystals/minefactoryreloaded/setup/MFRConfig.java
@@ -111,6 +111,8 @@ public class MFRConfig
 	public static Property craftSingleDSU;
 	public static Property enableMossyCobbleRecipe;
 	public static Property conveyorCaptureNonItems;
+        public static Property conveyorNeverCapturesPlayers;
+        public static Property conveyorNeverCapturesTCGolems;
 	public static Property playSounds;
 	public static Property fruitTreeSearchMaxVertical;
 	public static Property fruitTreeSearchMaxHorizontal;
@@ -271,6 +273,10 @@ public class MFRConfig
 		enableMossyCobbleRecipe.comment = "If true, mossy cobble can be crafted.";
 		conveyorCaptureNonItems = c.get(Configuration.CATEGORY_GENERAL, "Conveyor.CaptureNonItems", true);
 		conveyorCaptureNonItems.comment = "If false, conveyors will not grab non-item entities. Breaks conveyor mob grinders but makes them safe for golems, etc.";
+                conveyorNeverCapturesPlayers = c.get(Configuration.CATEGORY_GENERAL, "Conveyor.NeverCapturePlayers", false);
+                conveyorNeverCapturesPlayers.comment = "If true, conveyors will NEVER capture players regardless of other settings.";
+                conveyorNeverCapturesTCGolems = c.get(Configuration.CATEGORY_GENERAL, "Conveyor.NeverCaptureTCGolems", false);
+                conveyorNeverCapturesTCGolems.comment = "If true, conveyors will NEVER capture Thaumcraft golems regardless of other settings.";
 		playSounds = c.get(Configuration.CATEGORY_GENERAL, "PlaySounds", true);
 		playSounds.comment = "Set to false to disable the harvester's sound when a block is harvested.";
 		enableSlipperyRoads = c.get(Configuration.CATEGORY_GENERAL, "Road.Slippery", true);


### PR DESCRIPTION
These two new options make it possible to use Conveyor belts as a mob trap/animal wrangler while also not sucking yourself or your Thaumcraft golems into them. 

I've been using these for a while on a custom build. Very convenient.

edit: Not sure why the commit shows excess spaces. Those do not exist on my local copy of the files.
