### PR TITLE
Fixed tooltip entity name and optimised handler loop on safari nets.

### DIFF
--- a/src/powercrystals/minefactoryreloaded/item/ItemSafariNet.java
+++ b/src/powercrystals/minefactoryreloaded/item/ItemSafariNet.java
@@ -17,6 +17,7 @@ import net.minecraft.nbt.NBTTagDouble;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.Facing;
 import net.minecraft.util.Icon;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.world.World;
 import powercrystals.minefactoryreloaded.MFRRegistry;
@@ -65,11 +66,15 @@ public class ItemSafariNet extends ItemFactory
 		}
 		else
 		{
-			infoList.add(stack.getTagCompound().getString("id"));
+			infoList.add(StatCollector.translateToLocal("entity." + stack.getTagCompound().getString("id") + ".name")); // See Entity.getEntityName()
+			Class c = (Class)EntityList.stringToClassMapping.get(stack.getTagCompound().getString("id"));
+			if (c == null)
+			{
+				return;
+			}
 			for(ISafariNetHandler handler : MFRRegistry.getSafariNetHandlers())
 			{
-				Class c = (Class)EntityList.stringToClassMapping.get(stack.getTagCompound().getString("id"));
-				if(c != null && handler.validFor().isAssignableFrom(c))
+				if(handler.validFor().isAssignableFrom(c))
 				{
 					handler.addInformation(stack, player, infoList, advancedTooltips);
 				}

--- a/src/powercrystals/minefactoryreloaded/lang/en_US.lang
+++ b/src/powercrystals/minefactoryreloaded/lang/en_US.lang
@@ -153,6 +153,8 @@ tile.mfr.liquid.pinkslime.still.name = Pink Slime
 tile.mfr.liquid.chocolatemilk.still.name = Chocolate Milk
 tile.mfr.liquid.mushroomsoup.still.name = Mushroom Soup
 
+entity.MineFactoryReloaded.mfrEntityPinkSlime.name = Pink Slime
+
 item.mfr.bucket.milk.name = Milk Bucket
 item.mfr.bucket.sewage.name = Sewage Bucket
 item.mfr.bucket.sludge.name = Sludge Bucket


### PR DESCRIPTION
The name fix should handle non-MFR mobs just fine, assuming they have appropriate translation entries (but they'd need those, anyway, for death messages, etc). Handles vanilla mobs across the board.

Also, I only added "Pink Slime" to the en_US language file. Didn't know if dummy entries needed added to the others, too, so I simply left them alone.

The loop optimisation is minor; it's just a single class-mapping lookup instead of every loop iteration (and exits even before the loop, if the mapping is bogus).
