### PR TITLE
Clean rubber tree gen code

### DIFF
--- a/src/powercrystals/minefactoryreloaded/block/BlockFactoryMachine.java
+++ b/src/powercrystals/minefactoryreloaded/block/BlockFactoryMachine.java
@@ -42,7 +42,6 @@ import powercrystals.minefactoryreloaded.tile.machine.TileEntityCollector;
 import powercrystals.minefactoryreloaded.tile.machine.TileEntityDeepStorageUnit;
 import powercrystals.minefactoryreloaded.tile.machine.TileEntityItemRouter;
 import powercrystals.minefactoryreloaded.tile.machine.TileEntityLaserDrill;
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/powercrystals/minefactoryreloaded/core/GrindingDamage.java
+++ b/src/powercrystals/minefactoryreloaded/core/GrindingDamage.java
@@ -1,18 +1,48 @@
 package powercrystals.minefactoryreloaded.core;
 
+import java.util.Random;
+
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.StatCollector;
 
 public class GrindingDamage extends DamageSource
 {
+	protected int _msgCount;
+	protected Random _rand;
 	public GrindingDamage()
 	{
-		this(null);
+		this(null, 1);
+	}
+	
+	public GrindingDamage(String type)
+	{
+		this(type, 1);
 	}
 
-	public GrindingDamage(String type)
+	public GrindingDamage(String type, int deathMessages)
 	{
 		super(type == null ? "mfr.grinder" : type);
 		setDamageBypassesArmor();
 		setDamageAllowedInCreativeMode();
+		_msgCount = Math.max(deathMessages, 1);
+		_rand = new Random();
 	}
+	
+	@Override
+    public String getDeathMessage(EntityLiving par1EntityLiving)
+    {
+        EntityLiving entityliving1 = par1EntityLiving.func_94060_bK();
+        String s = "death.attack." + this.damageType;
+        if (_msgCount > 0)
+        {
+        	int msg = _rand.nextInt(_msgCount);
+        	if (msg != 0)
+        	{
+        		s += "." + msg;
+        	}
+        }
+        String s1 = s + ".player";
+        return entityliving1 != null && StatCollector.func_94522_b(s1) ? StatCollector.translateToLocalFormatted(s1, new Object[] {par1EntityLiving.getTranslatedEntityName(), entityliving1.getTranslatedEntityName()}): StatCollector.translateToLocalFormatted(s, new Object[] {par1EntityLiving.getTranslatedEntityName()});
+    }
 }

--- a/src/powercrystals/minefactoryreloaded/lang/en_US.lang
+++ b/src/powercrystals/minefactoryreloaded/lang/en_US.lang
@@ -331,5 +331,9 @@ circuit.mfr.xor.2 = Xor (2-Input)
 circuit.mfr.xor.3 = Xor (3-Input)
 circuit.mfr.xor.4 = Xor (4-Input)
 
-death.attack.mfr.slaughterhouse=%1$s was turned into Liquid Meat
+death.attack.mfr.slaughterhouse=%1$s was processed into Liquid Meat
+death.attack.mfr.slaughterhouse.player=%1$s was doomed to be processed into Liquid Meat by %2$s
+death.attack.mfr.slaughterhouse.1=%1$s was processed into meat sauce
+death.attack.mfr.slaughterhouse.1.player=%1$s was doomed to be processed into meat sauce by %2$s
 death.attack.mfr.grinder=%1$s was ground to bits
+death.attack.mfr.grinder.player=%2$s ensured %1$s was ground to bits

--- a/src/powercrystals/minefactoryreloaded/setup/WorldGenRubberTree.java
+++ b/src/powercrystals/minefactoryreloaded/setup/WorldGenRubberTree.java
@@ -92,9 +92,9 @@ public class WorldGenRubberTree extends WorldGenerator
 
 								block = Block.blocksList[blockId];
 
-								if((block != null &&
-										(!block.isAirBlock(world, xOffset, yOffset, zOffset) ||
-												!block.isLeaves(world, xOffset, yOffset, zOffset))))
+								if(block != null && !(block.isLeaves(world, xOffset, yOffset, zOffset) ||
+										block.isAirBlock(world, xOffset, yOffset, zOffset) ||
+										block.canBeReplacedByLeaves(world, xOffset, yOffset, zOffset)))
 								{
 									return false;
 								}
@@ -131,10 +131,12 @@ public class WorldGenRubberTree extends WorldGenerator
 
 							if(((xPos != center | zPos != center) ||
 									rand.nextInt(2) != 0 && var12 != 0) &&
-									(block == null || block.isAirBlock(world, xOffset, yOffset, zOffset) ||
+									(block == null || block.isLeaves(world, xOffset, yOffset, zOffset) ||
+									block.isAirBlock(world, xOffset, yOffset, zOffset) ||
 									block.canBeReplacedByLeaves(world, xOffset, yOffset, zOffset)))
 							{
-								this.setBlockAndMetadata(world, xOffset, yOffset, zOffset, MineFactoryReloadedCore.rubberLeavesBlock.blockID, 0);
+								this.setBlockAndMetadata(world, xOffset, yOffset, zOffset,
+										MineFactoryReloadedCore.rubberLeavesBlock.blockID, 0);
 							}
 						}
 					}
@@ -149,7 +151,8 @@ public class WorldGenRubberTree extends WorldGenerator
 					if(block == null || block.isAirBlock(world, x, y + yOffset, z)  ||
 							block.isLeaves(world, x, y + yOffset, z))
 					{
-						this.setBlockAndMetadata(world, x, y + yOffset, z, MineFactoryReloadedCore.rubberWoodBlock.blockID, 1);
+						this.setBlockAndMetadata(world, x, y + yOffset, z,
+								MineFactoryReloadedCore.rubberWoodBlock.blockID, 1);
 					}
 				}
 

--- a/src/powercrystals/minefactoryreloaded/setup/WorldGenRubberTree.java
+++ b/src/powercrystals/minefactoryreloaded/setup/WorldGenRubberTree.java
@@ -46,10 +46,11 @@ public class WorldGenRubberTree extends WorldGenerator
 	
 	public boolean growTree(World world, Random rand, int x, int y, int z)
 	{
-		int treeHeight = rand.nextInt(3) + 5;
-		boolean var7 = true;
+		int treeHeight = rand.nextInt(3) + 5,
+			worldHeight = world.getHeight();
+		boolean canGrow = true;
 		
-		if(y >= 1 && y + treeHeight + 1 <= 256)
+		if(y >= 1 && y + treeHeight + 1 <= worldHeight)
 		{
 			int var8;
 			int var10;
@@ -70,30 +71,32 @@ public class WorldGenRubberTree extends WorldGenerator
 					var9 = 2;
 				}
 				
-				for(var10 = x - var9; var10 <= x + var9 && var7; ++var10)
+				for(var10 = x - var9; var10 <= x + var9 && canGrow; ++var10)
 				{
-					for(var11 = z - var9; var11 <= z + var9 && var7; ++var11)
+					for(var11 = z - var9; var11 <= z + var9 && canGrow; ++var11)
 					{
-						if(var8 >= 0 && var8 < 256)
+						if(var8 >= 0 && var8 < worldHeight)
 						{
 							var12 = world.getBlockId(var10, var8, var11);
 							
 							Block block = Block.blocksList[var12];
 							
-							if(var12 != 0 && (block != null && !block.isLeaves(world, var10, var8, var11)))
+							if((block != null &&
+									(!block.isAirBlock(world, var10, var8, var11) ||
+											!block.isLeaves(world, var10, var8, var11))))
 							{
-								var7 = false;
+								canGrow = false;
 							}
 						}
 						else
 						{
-							var7 = false;
+							canGrow = false;
 						}
 					}
 				}
 			}
 			
-			if(!var7)
+			if(!canGrow)
 			{
 				return false;
 			}
@@ -101,15 +104,21 @@ public class WorldGenRubberTree extends WorldGenerator
 			{
 				var8 = world.getBlockId(x, y - 1, z);
 				
-				if((Block.blocksList[var8] != null && (var8 == Block.grass.blockID || var8 == Block.dirt.blockID || Block.blocksList[var8].canSustainPlant(
-						world, x, y - 1, z, ForgeDirection.UP, ((BlockSapling)MineFactoryReloadedCore.rubberSaplingBlock)))) && y < 256 - treeHeight - 1)
+				if((Block.blocksList[var8] != null && (var8 == Block.grass.blockID ||
+						var8 == Block.dirt.blockID ||
+						Block.blocksList[var8].canSustainPlant(world, x, y - 1, z, ForgeDirection.UP,
+								((BlockSapling)MineFactoryReloadedCore.rubberSaplingBlock)))) &&
+						y < worldHeight - treeHeight - 1)
 				{
-					this.setBlock(world, x, y - 1, z, Block.dirt.blockID);
-					int var16;
-					
-					for(var16 = y - 3 + treeHeight; var16 <= y + treeHeight; ++var16)
+					if (var8 == Block.grass.blockID)
 					{
-						var10 = var16 - (y + treeHeight);
+						this.setBlock(world, x, y - 1, z, Block.dirt.blockID);
+					}
+					int yOffset;
+					
+					for(yOffset = y - 3 + treeHeight; yOffset <= y + treeHeight; ++yOffset)
+					{
+						var10 = yOffset - (y + treeHeight);
 						var11 = 1 - var10 / 2;
 						
 						for(var12 = x - var11; var12 <= x + var11; ++var12)
@@ -120,26 +129,29 @@ public class WorldGenRubberTree extends WorldGenerator
 							{
 								int var15 = var14 - z;
 								
-								Block block = Block.blocksList[world.getBlockId(var12, var16, var14)];
+								Block block = Block.blocksList[world.getBlockId(var12, yOffset, var14)];
 								
-								if((Math.abs(var13) != var11 || Math.abs(var15) != var11 || rand.nextInt(2) != 0 && var10 != 0)
-										&& (block == null || block.canBeReplacedByLeaves(world, var12, var16, var14)))
+								if((Math.abs(var13) != var11 || Math.abs(var15) != var11 ||
+										rand.nextInt(2) != 0 && var10 != 0) &&
+										(block == null || block.isAirBlock(world, var12, yOffset, var14) ||
+											block.canBeReplacedByLeaves(world, var12, yOffset, var14)))
 								{
-									this.setBlockAndMetadata(world, var12, var16, var14, MineFactoryReloadedCore.rubberLeavesBlock.blockID, 0);
+									this.setBlockAndMetadata(world, var12, yOffset, var14, MineFactoryReloadedCore.rubberLeavesBlock.blockID, 0);
 								}
 							}
 						}
 					}
 					
-					for(var16 = 0; var16 < treeHeight; ++var16)
+					for(yOffset = 0; yOffset < treeHeight; ++yOffset)
 					{
-						var10 = world.getBlockId(x, y + var16, z);
+						var10 = world.getBlockId(x, y + yOffset, z);
 						
 						Block block = Block.blocksList[var10];
 						
-						if(var10 == 0 || block == null || block.isLeaves(world, x, y + var16, z))
+						if(block == null || block.isAirBlock(world, x, y + yOffset, z)  ||
+								block.isLeaves(world, x, y + yOffset, z))
 						{
-							this.setBlockAndMetadata(world, x, y + var16, z, MineFactoryReloadedCore.rubberWoodBlock.blockID, 1);
+							this.setBlockAndMetadata(world, x, y + yOffset, z, MineFactoryReloadedCore.rubberWoodBlock.blockID, 1);
 						}
 					}
 					

--- a/src/powercrystals/minefactoryreloaded/tile/machine/TileEntityPlanter.java
+++ b/src/powercrystals/minefactoryreloaded/tile/machine/TileEntityPlanter.java
@@ -2,6 +2,7 @@ package powercrystals.minefactoryreloaded.tile.machine;
 
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.ForgeDirection;
 import powercrystals.core.position.BlockPosition;
 import powercrystals.minefactoryreloaded.MFRRegistry;
@@ -68,8 +69,7 @@ public class TileEntityPlanter extends TileEntityFactoryPowered
 			//skip planting attempt if there's no stack in that slot, or if there's a template item that's not matched
 			if(availableStack == null ||
 					(match != null &&
-					(match.itemID != availableStack.itemID ||
-					match.getItemDamage() != availableStack.getItemDamage())))
+					!stacksEqual(match, availableStack)))
 			{
 				continue;
 			}
@@ -101,6 +101,29 @@ public class TileEntityPlanter extends TileEntityFactoryPowered
 	public String getInvName()
 	{
 		return "Planter";
+	}
+	
+	@SuppressWarnings("null")
+	// eclipse doesn't understand boolean | and warns about impossible potential NPE 
+	private boolean stacksEqual(ItemStack a, ItemStack b)
+	{
+		if (a == null | b == null ||
+				(a.itemID != b.itemID) ||
+				(a.getItemDamage() != b.getItemDamage()) ||
+				a.hasTagCompound() != b.hasTagCompound())
+		{
+			return false;
+		}
+		if (!a.hasTagCompound())
+		{
+			return true;
+		}
+		NBTTagCompound tagA = (NBTTagCompound)a.getTagCompound().copy(),
+				tagB = (NBTTagCompound)b.getTagCompound().copy();
+		tagA.removeTag("display"); tagB.removeTag("display");
+		tagA.removeTag("ench"); tagB.removeTag("ench");
+		tagA.removeTag("RepairCost"); tagB.removeTag("RepairCost");
+		return tagA.equals(tagB);
 	}
 	
 	//assumes a 3x3 grid in inventory slots 0-8

--- a/src/powercrystals/minefactoryreloaded/tile/machine/TileEntitySlaughterhouse.java
+++ b/src/powercrystals/minefactoryreloaded/tile/machine/TileEntitySlaughterhouse.java
@@ -18,7 +18,7 @@ public class TileEntitySlaughterhouse extends TileEntityGrinder
 	public TileEntitySlaughterhouse()
 	{
 		super(Machine.Slaughterhouse);
-		_damageSource = new GrindingDamage("mfr.slaughterhouse");
+		_damageSource = new GrindingDamage("mfr.slaughterhouse", 2);
 	}
 	
 	@Override


### PR DESCRIPTION
Planter change is non-breaking and non-functional in 1.5.2, 1.6 should fix the serialization-related issues; will allow plantable mod items to be based on NBT in addition to id:meta, should a mod make use of that
